### PR TITLE
Install phantomjs 2.5.0-beta on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: MIT + file LICENSE
 LazyData: true
 URL: https://github.com/rstudio/webdriver
 BugReports: https://github.com/rstudio/webdriver/issues
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.1
 Imports:
     callr (>= 3.4.0),
     base64enc,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 1.0.6.9000
 =====
 
+* On Windows, `install_phantomjs()` now installs version 2.5.0-beta by default, due to some font rendering issues with version 2.1.1. (#102)
 
 1.0.6
 =====

--- a/R/install-phantomjs.R
+++ b/R/install-phantomjs.R
@@ -19,7 +19,11 @@
 #' writable, the directory \file{PhantomJS} under the installation directory of
 #' the \pkg{webdriver} package will be tried. If this directory still fails, you
 #' will have to install PhantomJS by yourself.
-#' @param version The version number of PhantomJS.
+#' @param version The version number of PhantomJS. If the value is "auto", then
+#'   on Mac and Linux, it will download version 2.1.1, and on Windows, it will
+#'   download 2.5.0-beta. This is because 2.1.1 on Windows has some font
+#'   rendering issues that are fixed by 2.5.0-beta, but on other platforms,
+#'   2.5.0-beta does not install and run reliably.
 #' @param baseURL The base URL for the location of PhantomJS binaries for
 #'   download. If the default download site is unavailable, you may specify an
 #'   alternative mirror, such as
@@ -27,8 +31,16 @@
 #' @return \code{NULL} (the executable is written to a system directory).
 #' @export
 
-install_phantomjs <- function(version = '2.1.1',
+install_phantomjs <- function(version = 'auto',
     baseURL = 'https://github.com/wch/webshot/releases/download/v0.3.1/') {
+
+  if (version == "auto") {
+    if (is_windows()) {
+      version <- "2.5.0-beta"
+    } else {
+      version <- "2.1.1"
+    }
+  }
 
   if (!grepl("/$", baseURL))
     baseURL <- paste0(baseURL, "/")

--- a/man/install_phantomjs.Rd
+++ b/man/install_phantomjs.Rd
@@ -4,11 +4,17 @@
 \alias{install_phantomjs}
 \title{Install PhantomJS}
 \usage{
-install_phantomjs(version = "2.1.1",
-  baseURL = "https://github.com/wch/webshot/releases/download/v0.3.1/")
+install_phantomjs(
+  version = "auto",
+  baseURL = "https://github.com/wch/webshot/releases/download/v0.3.1/"
+)
 }
 \arguments{
-\item{version}{The version number of PhantomJS.}
+\item{version}{The version number of PhantomJS. If the value is "auto", then
+on Mac and Linux, it will download version 2.1.1, and on Windows, it will
+download 2.5.0-beta. This is because 2.1.1 on Windows has some font
+rendering issues that are fixed by 2.5.0-beta, but on other platforms,
+2.5.0-beta does not install and run reliably.}
 
 \item{baseURL}{The base URL for the location of PhantomJS binaries for
 download. If the default download site is unavailable, you may specify an

--- a/man/key.Rd
+++ b/man/key.Rd
@@ -4,7 +4,9 @@
 \name{key}
 \alias{key}
 \title{Special keys, so that we can refer to them with an easier syntax}
-\format{An object of class \code{list} of length 51.}
+\format{
+An object of class \code{list} of length 51.
+}
 \usage{
 key
 }

--- a/man/run_phantomjs.Rd
+++ b/man/run_phantomjs.Rd
@@ -4,8 +4,7 @@
 \alias{run_phantomjs}
 \title{Start up phantomjs on localhost, and a random port}
 \usage{
-run_phantomjs(debugLevel = c("INFO", "ERROR", "WARN", "DEBUG"),
-  timeout = 5000)
+run_phantomjs(debugLevel = c("INFO", "ERROR", "WARN", "DEBUG"), timeout = 5000)
 }
 \arguments{
 \item{debugLevel}{Phantom.js debug level, possible values: \code{"INFO"},

--- a/man/webdriver.Rd
+++ b/man/webdriver.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{webdriver}
 \alias{webdriver}
-\alias{webdriver-package}
 \title{'WebDriver' Client for 'PhantomJS'}
 \description{
 A client for the 'WebDriver' 'API'. It allows driving a (probably


### PR DESCRIPTION
Basically the same as https://github.com/wch/webshot/pull/102

Phantomjs 2.1.1 on Windows has some problems rendering certain fonts (e.g., many Font-Awesome icons, and some bold fonts), and using 2.5.0-beta fixes some of these issues. (Note that we tried 2.5.0-beta2 on Windows, and it did not work properly.)

This PR does not cause 2.5.0-beta to install on Mac and Linux. On Mac, running phantomjs simply crashes, and on Linux, it doesn't run on newer versions due to dynamic linking to an old version of libpng which is not present.