### PR TITLE
When parsing a response, return `NULL` instead of `""` if there is no content type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 1.0.6.9000
 =====
 
+* If there is not content type in a request response, return `NULL` instead of `""`. This allows for graceful fall-through within webdriver. (#72)
+
 
 1.0.6
 =====

--- a/R/requests.R
+++ b/R/requests.R
@@ -81,7 +81,7 @@ parse_response <- function(response) {
   content_type <- headers(response)$`content-type`
 
   if (is.null(content_type) || length(content_type) == 0) {
-    ""
+    NULL
 
   } else if (grepl("^application/json", content_type, ignore.case = TRUE)) {
     fromJSON(content(response, as = "text"), simplifyVector = FALSE)


### PR DESCRIPTION
When parsing a request, if there is no content type, `""` was previously returned. This caused errors down the road as `("")$value` is not possible.  

If `NULL` is return instead, `(NULL)$value` will return `NULL`.

------------------------------

This PR should only be merged if no action comes out of https://github.com/jeroen/curl/issues/257